### PR TITLE
fix: name InputField for creating new Folders is properly fixed

### DIFF
--- a/src/main/java/code/frontend/gui/sidebar/SidebarFolderManager.java
+++ b/src/main/java/code/frontend/gui/sidebar/SidebarFolderManager.java
@@ -388,21 +388,34 @@ public class SidebarFolderManager extends VBox {
                 TRANSITION.playFromStart();
             }
         });
+
+        final ChangeListener<Number> AUTO_SCROLL_DOWN_LISTENER = new ChangeListener<Number>() {
+            public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+                if (SCROLL_PANE_CONTENT.getChildren().contains(CONTAINER)) {
+                    SCROLL_PANE.setVvalue(1); // scroll all the way down
+                }
+            };
+        };
+
         NAME_INPUT.getTextField().focusedProperty().addListener(new ChangeListener<Boolean>() {
             @Override
             public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
-                if (!newValue)
+                if (!newValue) {
+                    SCROLL_PANE_CONTENT.heightProperty().removeListener(AUTO_SCROLL_DOWN_LISTENER);
                     instance.repopulate(); // if focus lost, treat it like user wants to cancel
+                }
             }
         });
 
+        this.SCROLL_PANE_CONTENT.heightProperty().addListener(AUTO_SCROLL_DOWN_LISTENER);
+
         CONTAINER.getChildren().addAll(TOP_HINT, NAME_INPUT, HINT);
         this.SCROLL_PANE_CONTENT.getChildren().add(CONTAINER);
+
         Platform.runLater(new Runnable() {
             @Override
             public void run() {
                 NAME_INPUT.getTextField().requestFocus();
-                SCROLL_PANE.setVvalue(1); // scroll all the way down
             }
         });
     }


### PR DESCRIPTION
- when the "+ New folder" button was clicked and the InputField was added to the ScrollPane's content...
- the automatic scrolling down was executing unreliably and usually executed before the scrollpane adjusted its max viewport height
- hence the automatic scrolling was ineffective and the InputField would be hidden, requiring the user to scroll down to find it

Instead of relying on `runLater` to scroll down, a new `ChangeListener` is added to the `SCROLL_PANE_CONTENT`'s **height property**. This is so that the code contained within the `ChangeListener` is executed **because of** a change in child components (which have affected the **height property**).

Following documentation advice, the ChangeListener is **removed** when the name InputField is removed from `SCROLL_PANE_CONTENT`.